### PR TITLE
feat: 個人リポジトリへのミラーリングワークフローを追加

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,27 @@
+name: Mirror to Personal Repo
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v3
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Push to personal repo
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git remote add mirror git@github.com:ashitabo/ashitabo_mirror.git
+          git push --mirror mirror


### PR DESCRIPTION
新しいGitHub Actionsワークフローを作成し、mainブランチへのプッシュ時にソースリポジトリを個人リポジトリにミラーリングする機能を追加しました。SSHのセットアップを行い、GitHub Actionsのユーザー名とメールを設定して、ミラーリモートにプッシュします。