### PR TITLE
feat: actions/checkoutのバージョンをv4に更新

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,7 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: SSHエージェントのセットアップ
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up SSH
         run: |


### PR DESCRIPTION
- .github/workflows/mirror.ymlのCheckout source repoステップで、actions/checkoutをv3からv4に変更しました。
- SSHエージェントのセットアップステップを追加しました。